### PR TITLE
Update jackson and guava dependencies.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
 
     <!-- core dependencies -->
     <dep.junit.version>4.11</dep.junit.version>
-    <dep.slf4j.version>1.7.5</dep.slf4j.version>
+    <dep.slf4j.version>1.7.6</dep.slf4j.version>
     <dep.metrics.version>2.2.0</dep.metrics.version>
     <dep.guava.version>16.0.1</dep.guava.version>
     <dep.joda-time.version>2.3</dep.joda-time.version>


### PR DESCRIPTION
Some maven enforcer plugin dependency convergences are complaining
because we are pulling in older versions of these libraries.
