### PR TITLE
java 8 and other version upgrades

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
   </scm>
 
   <properties>
-    <project.build.targetJdk>1.7</project.build.targetJdk>
+    <project.build.targetJdk>1.8</project.build.targetJdk>
 
     <!-- custom properties prefixed with 'at.' -->
     <at.test.excluded.groups />
@@ -55,13 +55,13 @@
     <dep.junit.version>4.11</dep.junit.version>
     <dep.slf4j.version>1.7.5</dep.slf4j.version>
     <dep.metrics.version>2.2.0</dep.metrics.version>
-    <dep.guava.version>15.0</dep.guava.version>
+    <dep.guava.version>17.0</dep.guava.version>
     <dep.joda-time.version>2.3</dep.joda-time.version>
     <dep.jackson.version>2.2.3</dep.jackson.version>
 
     <!-- plugins referenced multiple times -->
     <dep.plugin.surefire.version>2.16</dep.plugin.surefire.version>
-    <dep.plugin.jacoco.version>0.6.4.201312101107</dep.plugin.jacoco.version>
+    <dep.plugin.jacoco.version>0.7.1.201405082137</dep.plugin.jacoco.version>
     <dep.plugin.javadoc.version>2.9.1</dep.plugin.javadoc.version>
     <dep.plugin.findbugs.version>2.5.3</dep.plugin.findbugs.version>
     <dep.plugin.checkstyle.configLocation>https://raw.github.com/addthis/addthis-oss-jar-pom/v3.1.0/checkstyle/default.xml</dep.plugin.checkstyle.configLocation>
@@ -149,6 +149,9 @@
             <execution>
               <id>attach-javadocs</id>
               <phase>verify</phase>
+              <configuration>
+                <additionalparam>-Xdoclint:none</additionalparam>
+              </configuration>
               <goals>
                 <goal>jar</goal>
               </goals>


### PR DESCRIPTION
- jacoco plugin needed a version bump to play nice with java 8
- added config to disable java 8 doclinting by default (runs a lot
  of checks by default that we don't always pass..)
- guava bump cause might as well
