### PR TITLE
move -Xdoclint:none to jdk8 activated profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,6 @@
     <version>2.1.0-SNAPSHOT</version>
   </parent>
 
-  <groupId>com.addthis.common.build.maven.pom</groupId>
   <artifactId>jar-pom</artifactId>
   <version>3.2.0-SNAPSHOT</version>
   <packaging>pom</packaging>
@@ -163,7 +162,6 @@
           <version>${dep.plugin.javadoc.version}</version>
           <configuration>
             <source>${project.build.targetJdk}</source>
-            <target>${project.build.targetJdk}</target>
             <encoding>${project.build.sourceEncoding}</encoding>
             <quiet>true</quiet>
           </configuration>
@@ -360,7 +358,6 @@
         <version>${dep.plugin.javadoc.version}</version>
         <configuration>
           <source>${project.build.targetJdk}</source>
-          <target>${project.build.targetJdk}</target>
           <encoding>${project.build.sourceEncoding}</encoding>
           <quiet>true</quiet>
         </configuration>


### PR DESCRIPTION
this should prevent jdk7 build environments from complaining about
-Xdoclint being an unknown flag.
